### PR TITLE
added gnome-shell 3.18 as supported

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,7 @@
     "description": "Unmute the microphone only when you have something to say.",
     "uuid": "nothing-to-say@extensions.gnome.wouter.bolsterl.ee",
     "shell-version": [
+        "3.18",
         "3.20",
         "3.22",
         "3.24"


### PR DESCRIPTION
I have tested the extension under 3.18 (which is shipped with Ubuntu 16.04 LTS) and it seems to work perfectly. I have added the version to the supported list so people can install from the extensions website.