### PR TITLE
No longer set x_fill/y_fill fields for Gnome 3.38 compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -162,8 +162,6 @@ function enable() {
     style_class: 'panel-button',
     reactive: true,
     can_focus: true,
-    //x_fill: true,
-    //y_fill: false,
     track_hover: true,
     visible: microphone.active});
   panel_button.set_child(panel_icon);

--- a/extension.js
+++ b/extension.js
@@ -162,8 +162,8 @@ function enable() {
     style_class: 'panel-button',
     reactive: true,
     can_focus: true,
-    x_fill: true,
-    y_fill: false,
+    //x_fill: true,
+    //y_fill: false,
     track_hover: true,
     visible: microphone.active});
   panel_button.set_child(panel_icon);


### PR DESCRIPTION
Make it work with gnome-3.38.

Fixes #19.