### PR TITLE
Fix osd setting being ignored on capture start

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -180,7 +180,7 @@ function enable() {
       panel_button.icon.remove_style_class_name(MICROPHONE_ACTIVE_STYLE_CLASS);
     }
     panel_button.visible = icon_should_be_visible(microphone.active);
-    if (initialised || microphone.active)
+    if (settings.get_boolean("show-osd") && (initialised || microphone.active))
       show_osd(
         microphone.active ? "Microphone activated" : "Microphone deactivated",
         microphone.muted


### PR DESCRIPTION
Currently, whenever an app starts recording, the osd always shows up, ignoring the corresponding setting.
In my opinion, this doesn't feel right. This fixes it so that the extension actually respects the user's preference.

If a clear indication about a recording commencing is desired, beyond the customizable top bar recording mic indicator, that should ideally be a separate setting.