### PR TITLE
Do not fail completely on missing GStreamer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,13 +126,15 @@ put a clone of this repository (or a symlink) in this directory::
 note that the files must be directly in this directory, not in a
 subdirectory thereof.
 
-starting with version 14, due to the new sound notification feature,
-it is also required having the gobject introspection data for the gstreamer plugins
-base library installed in your system, to prevent:
+starting with version 14, the new sound notification feature is available and enabled by default.
+it requires the gobject introspection data for the gstreamer plugins base library installed in your system.
+having no sound, check your system logs for:
+
+  Unable to import sound module. Playing sound is not available. Is GStremer package installed?
 
   Requiring GstAudio, version none: Typelib file for namespace 'GstAudio' (any version) not found
 
-for ubuntu::
+and eventually install it. for ubuntu::
 
   sudo apt install gir1.2-gst-plugins-base-1.0
 

--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,7 @@ starting with version 14, the new sound notification feature is available and en
 it requires the gobject introspection data for the gstreamer plugins base library installed in your system.
 having no sound, check your system logs for:
 
-  Unable to import sound module. Playing sound is not available. Is GStremer package installed?
+  Unable to import sound module. Playing sound is not available. Is GStreamer package installed?
 
   Requiring GstAudio, version none: Typelib file for namespace 'GstAudio' (any version) not found
 

--- a/extension.js
+++ b/extension.js
@@ -125,7 +125,7 @@ function try_to_import_or_return_null(func_returning_import) {
   try {
     return func_returning_import();
   } catch(e) {
-    log(`nothing-to-say: Unable to import sound module. Playing sound is not available. Is GStremer package installed?`);
+    log(`nothing-to-say: Unable to import sound module. Playing sound is not available. Is GStreamer package installed?`);
     log(`nothing-to-say: ${e}`);
     return null;
   }

--- a/extension.js
+++ b/extension.js
@@ -4,8 +4,6 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
-const Gst = imports.gi.Gst;
-const GstAudio = imports.gi.GstAudio;
 const Gvc = imports.gi.Gvc;
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
@@ -13,6 +11,10 @@ const PanelMenu = imports.ui.panelMenu;
 const Shell = imports.gi.Shell;
 const Signals = imports.signals;
 const St = imports.gi.St;
+
+const Gst = try_to_import_or_return_null(() => { return imports.gi.Gst; });
+const GstAudio = try_to_import_or_return_null(() => { return imports.gi.GstAudio; });
+const isPlayingSoundSupported = Gst != null && GstAudio != null;
 
 const Extension = ExtensionUtils.getCurrentExtension();
 
@@ -41,9 +43,11 @@ class Microphone {
     this.mixer_control.connect("default-source-changed", refresh_cb);
     this.mixer_control.connect("stream-added", refresh_cb);
     this.mixer_control.connect("stream-removed", refresh_cb);
-    Gst.init(null);
-    this.on_sound = init_sound("on");
-    this.off_sound = init_sound("off");
+    if (isPlayingSoundSupported) {
+      Gst.init(null);
+      this.on_sound = init_sound("on");
+      this.off_sound = init_sound("off");
+    }
     this.refresh();
   }
 
@@ -117,6 +121,16 @@ const MicrophonePanelButton = GObject.registerClass(
   }
 );
 
+function try_to_import_or_return_null(func_returning_import) {
+  try {
+    return func_returning_import();
+  } catch(e) {
+    log(`nothing-to-say: Unable to import sound module. Playing sound is not available. Is GStremer package installed?`);
+    log(`nothing-to-say: ${e}`);
+    return null;
+  }
+}
+
 function init_sound(name) {
   const playbin = Gst.ElementFactory.make("playbin", null);
   const path = Extension.dir.get_child(`sounds/${name}.ogg`).get_path();
@@ -161,7 +175,7 @@ function on_activate({ give_feedback }) {
     if (give_feedback) {
       show_osd(null, false, microphone.level);
     }
-    if (settings.get_boolean("play-feedback-sounds")) {
+    if (isPlayingSoundSupported && settings.get_boolean("play-feedback-sounds")) {
       play_sound(microphone.on_sound);
     }
   } else {
@@ -179,7 +193,7 @@ function on_activate({ give_feedback }) {
       if (give_feedback) {
         show_osd(null, true, 0);
       }
-      if (settings.get_boolean("play-feedback-sounds")) {
+      if (isPlayingSoundSupported && settings.get_boolean("play-feedback-sounds")) {
         play_sound(microphone.off_sound);
       }
     });

--- a/extension.js
+++ b/extension.js
@@ -12,11 +12,11 @@ const Shell = imports.gi.Shell;
 const Signals = imports.signals;
 const St = imports.gi.St;
 
+const Extension = ExtensionUtils.getCurrentExtension();
+
 const Gst = try_to_import_or_return_null(() => { return imports.gi.Gst; });
 const GstAudio = try_to_import_or_return_null(() => { return imports.gi.GstAudio; });
 const isPlayingSoundSupported = Gst != null && GstAudio != null;
-
-const Extension = ExtensionUtils.getCurrentExtension();
 
 const EXCLUDED_APPLICATION_IDS = [
   "org.gnome.VolumeControl",
@@ -125,8 +125,8 @@ function try_to_import_or_return_null(func_returning_import) {
   try {
     return func_returning_import();
   } catch(e) {
-    log(`nothing-to-say: Unable to import sound module. Playing sound is not available. Is GStreamer package installed?`);
-    log(`nothing-to-say: ${e}`);
+    log(`${Extension.metadata.uuid}: Unable to import sound module. Playing sound is not available. Is GStreamer package installed?`);
+    log(`${Extension.metadata.uuid}: ${e}`);
     return null;
   }
 }

--- a/prefs.js
+++ b/prefs.js
@@ -112,9 +112,29 @@ function buildPrefsWidget() {
   );
   prefsWidget.attach(feedbackSoundsSwitch, 1, 4, 1, 1);
 
+  const playingSoundNotSupportedLabel = new Gtk.Label({
+    halign: Gtk.Align.START,
+    visible: !is_playing_sound_supported(),
+  });
+  playingSoundNotSupportedLabel.set_markup("<span foreground='red'>WARNING. Playing sound is not supported on this system. Is GStreamer package installed?</span>");
+  prefsWidget.attach(playingSoundNotSupportedLabel, 0, 5, 1, 1);
+
   if (GTK_VERSION == 3) {
     prefsWidget.show_all();
   }
 
   return prefsWidget;
 }
+
+function is_playing_sound_supported() {
+  try {
+    imports.gi.Gst;
+    imports.gi.GstAudio;
+    return true;
+  } catch(e) {
+    log(`${Extension.metadata.uuid}: Playing sound is not supported on this system. Is GStremer package installed?`);
+    log(`${Extension.metadata.uuid}: ${e}`);
+    return false;
+  }
+}
+

--- a/prefs.js
+++ b/prefs.js
@@ -114,13 +114,18 @@ function buildPrefsWidget() {
   prefsWidget.attach(feedbackSoundsSwitch, 1, 4, 1, 1);
   feedbackSoundsSwitch.set_sensitive(isPlayingSoundSupported);
 
-  const playingSoundNotSupportedLabel = new Gtk.Label({
-    halign: Gtk.Align.START,
-  });
-  playingSoundNotSupportedLabel.set_markup("<span foreground='red'>WARNING. Playing sound is not supported on this system. Is GStreamer package installed?</span>");
-  playingSoundNotSupportedLabel.set_wrap(true);
-  playingSoundNotSupportedLabel.set_visible(!isPlayingSoundSupported);
-  prefsWidget.attach(playingSoundNotSupportedLabel, 0, 5, 1, 1);
+  if (!isPlayingSoundSupported) {
+    const playingSoundNotSupportedLabel = new Gtk.Label({
+      halign: Gtk.Align.START,
+    });
+    playingSoundNotSupportedLabel.set_markup("<span foreground='red'>WARNING. Playing sound is not supported on this system. Is GStreamer package installed?</span>");
+    if (GTK_VERSION == 3) {
+      playingSoundNotSupportedLabel.set_line_wrap(true);
+    } else {
+      playingSoundNotSupportedLabel.set_wrap(true);
+    }
+    prefsWidget.attach(playingSoundNotSupportedLabel, 0, 5, 1, 1);
+  }
 
   if (GTK_VERSION == 3) {
     prefsWidget.show_all();

--- a/prefs.js
+++ b/prefs.js
@@ -15,6 +15,7 @@ function init() {}
 function buildPrefsWidget() {
   this.settings = ExtensionUtils.getSettings();
 
+  const isPlayingSoundSupported = is_playing_sound_supported();
   let gridProperties = {
     column_spacing: 12,
     row_spacing: 12,
@@ -111,12 +112,14 @@ function buildPrefsWidget() {
     Gio.SettingsBindFlags.DEFAULT
   );
   prefsWidget.attach(feedbackSoundsSwitch, 1, 4, 1, 1);
+  feedbackSoundsSwitch.set_sensitive(isPlayingSoundSupported);
 
   const playingSoundNotSupportedLabel = new Gtk.Label({
     halign: Gtk.Align.START,
-    visible: !is_playing_sound_supported(),
   });
   playingSoundNotSupportedLabel.set_markup("<span foreground='red'>WARNING. Playing sound is not supported on this system. Is GStreamer package installed?</span>");
+  playingSoundNotSupportedLabel.set_wrap(true);
+  playingSoundNotSupportedLabel.set_visible(!isPlayingSoundSupported);
   prefsWidget.attach(playingSoundNotSupportedLabel, 0, 5, 1, 1);
 
   if (GTK_VERSION == 3) {
@@ -132,7 +135,7 @@ function is_playing_sound_supported() {
     imports.gi.GstAudio;
     return true;
   } catch(e) {
-    log(`${Extension.metadata.uuid}: Playing sound is not supported on this system. Is GStremer package installed?`);
+    log(`${Extension.metadata.uuid}: Playing sound is not supported on this system. Is GStreamer package installed?`);
     log(`${Extension.metadata.uuid}: ${e}`);
     return false;
   }


### PR DESCRIPTION
If optional sound dependencies are not available, just print warning
and skip the sound part instead of failing completely.

It would prevent #47 and #52.

Btw, I am not a JavaScript developer. Feel free to fix naming convention or lame constructions.
Btw2, the warning in preferences could be "got prettier":

![image](https://user-images.githubusercontent.com/148013/159117609-f7a16e63-bee4-4264-b8fe-2c0ef8b3425c.png)
