### PR TITLE
Bump supported Gnome Shell version to 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "3.36.9",
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/wbolster/nothing-to-say",
   "uuid": "nothing-to-say@extensions.gnome.wouter.bolsterl.ee"


### PR DESCRIPTION
This extension seems to work just fine with Gnome Shell 42.
Adding 42 to the list of supported strings so people updating to 42 can continue to use this without manually editing its metadata and restarting their session (on Wayland anyway).