### PR TITLE
Fix OSD level showing as empty

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -98,7 +98,7 @@ class Microphone {
   get level() {
     if (!this.stream) return 0;
     return (
-      (100 * this.stream.get_volume()) / this.mixer_control.get_vol_max_norm()
+      (this.stream.get_volume()) / this.mixer_control.get_vol_max_norm()
     );
   }
 }


### PR DESCRIPTION
The scale was 0 - 100 instead of 0.0 - 1.0.

Fixes #25