### PR TITLE
Sound Notification: Fix Node Suspend on Idle (Bluetooth battery drain)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -127,6 +127,15 @@ function init_sound(dir, name) {
   const sink = Gst.ElementFactory.make("pulsesink", "sink");
   playbin.set_property("audio-sink", sink);
   playbin.set_volume(GstAudio.StreamVolumeFormat.LINEAR, 0.5);
+
+  // Fix audio node suspend-on-idle; stop playback at end-of-stream
+  const bus = playbin.get_bus();
+  bus.add_signal_watch();
+  bus.connect('message', (_bus, msg) => {
+    if (msg.type === Gst.MessageType.EOS)
+      playbin.set_state(Gst.State.NULL);
+  });
+
   return playbin;
 }
 


### PR DESCRIPTION
Enabling "Sound notification" seem to cause Bluetooth battery drain.

It seems the mic on/off sound state doesn't get reset after playback; audio source state is still "Running".

Fix resets playback at end-of-stream, so Pipewire can auto-suspend node (e.g. Bluetooth headset).

----

## Note

I'm not familiar with gstreamer API so welcome any feedback if there's a better way to do this.

## Test

1. Open [coppwr](https://flathub.org/apps/io.github.dimtpap.coppwr)
2. Mute and unmute (with "Sound notification" enabled)
3. Check: "gnome-shell" audio source node auto disconnects and disappears
4. Check: Output node "state" == Idle > Suspended

Before fix, the audio source node remains connected (step 3), and output node state remains "Running" (step 4) - hence the battery drain.