### PR TITLE
Simplify playing sounds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,22 +126,6 @@ put a clone of this repository (or a symlink) in this directory::
 note that the files must be directly in this directory, not in a
 subdirectory thereof.
 
-starting with version 14, the new sound notification feature is available and enabled by default.
-it requires the gobject introspection data for the gstreamer plugins base library installed in your system.
-having no sound, check your system logs for:
-
-  Unable to import sound module. Playing sound is not available. Is GStreamer package installed?
-
-  Requiring GstAudio, version none: Typelib file for namespace 'GstAudio' (any version) not found
-
-and eventually install it. for ubuntu::
-
-  sudo apt install gir1.2-gst-plugins-base-1.0
-
-for fedora::
-
-  sudo dnf install gstreamer1-plugins-base
-
 why?
 ====
 

--- a/prefs.js
+++ b/prefs.js
@@ -4,8 +4,6 @@ import Gio from "gi://Gio";
 import Gtk from "gi://Gtk";
 import GObject from "gi://GObject";
 import Adw from "gi://Adw";
-import Gst from "gi://Gst";
-import GstAudio from "gi://GstAudio";
 
 import { ExtensionPreferences } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
@@ -144,18 +142,5 @@ export default class extends ExtensionPreferences {
       Gio.SettingsBindFlags.DEFAULT,
     );
     group.add(feedbackSoundsSwitch);
-
-    // no sound alert row
-    const isPlayingSoundSupported = Gst != null && GstAudio != null;
-    if (!isPlayingSoundSupported) {
-      const playingSoundNotSupportedLabel = new Gtk.Label({
-        halign: Gtk.Align.START,
-      });
-      playingSoundNotSupportedLabel.set_markup(
-        "<span foreground='red'>WARNING. Playing sound is not supported on this system. Is GStreamer package installed?</span>",
-      );
-      playingSoundNotSupportedLabel.set_wrap(true);
-      group.add(playingSoundNotSupportedLabel);
-    }
   }
 }


### PR DESCRIPTION
Uses a different sound player that doesn't require extra libraries installed. Breaks out audio player into a separate class.

Fixes #71