### PR TITLE
Add GNOME 50 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,7 @@
   "name": "Nothing to say",
   "settings-schema": "org.gnome.shell.extensions.nothing-to-say",
   "shell-version": [
+    "50",
     "49",
     "48",
     "47",


### PR DESCRIPTION
It's that time of the year again :).

This adds `50` to supported GNOME versions. No relevant changes to the shell.

Tested and verified.