### PR TITLE
Fix unresponsive top panel icon in GNOME 50+

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,6 +7,7 @@ import Meta from "gi://Meta";
 import Shell from "gi://Shell";
 import Gvc from "gi://Gvc";
 import GObject from "gi://GObject";
+import Clutter from "gi://Clutter";
 
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
 import * as PanelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
@@ -128,14 +129,27 @@ const MicrophonePanelButton = GObject.registerClass(
         style_class: "system-status-icon",
       });
       this.add_child(this.icon);
-      this.connect("button-press-event", (_, event) => {
-        if (event.get_button() === 3) {
-          // Right click.
-          extension.openPreferences();
-        } else {
-          on_activate({ give_feedback: false });
-        }
-      });
+
+      const shellVersion = Number(Config.PACKAGE_VERSION.split(".")[0]);
+      if (shellVersion >= 50) {
+        this._clickGesture.connect('recognize', (gesture) => {
+          if (gesture.get_button() == Clutter.BUTTON_SECONDARY) {
+            // Right click.
+            extension.openPreferences();
+          } else {
+            on_activate({ give_feedback: false });
+          }
+        });
+      } else {
+        this.connect("button-press-event", (_, event) => {
+          if (event.get_button() === 3) {
+            // Right click.
+            extension.openPreferences();
+          } else {
+            on_activate({ give_feedback: false });
+          }
+        });
+      }
     }
   },
 );


### PR DESCRIPTION
Fixes the issue where the top panel icon stopped working in GNOME 50 (and above), as pointed out by @BashBandito in [this comment](https://github.com/wbolster/nothing-to-say/pull/86#issuecomment-4321136992).

Shell version 50 adds gestures to all top panel icons, which "consume" the low-level event `button-press-event` currently used by this extension to handle clicks itself. The idiomatic way to handle clicks is to add `Clutter.Action`s to the icons instead: earlier `ClickAction`, and now its successor `ClickGesture`. With gestures, this move is effectively forced as adding one to a `Clutter.Actor`, which is what panel icons are, prevents the low-level events from ever reaching the Actor.

This fix checks for the shell version and if it's above 50, it uses the newly-existing gesture, otherwise retaining its current behaviour.

---

This took a bit longer than expected as the change in the shell is pretty innocuous. The real issue was the behaviour of gestures, which are a part of Clutter, which is now a part of Mutter. The documentation says nothing about it ([except maybe an incomplete hint](https://gjs-docs.gnome.org/clutter17~17/clutter.gesture#:~:text=Those%20states%20also%20define%20whether%20to%20block%20or%0Aallow%20event%20delivery%3A)) and the C source is a bit tricky to map out. The code that holds back events from Actors if a gesture is attached to them is handled separately from the usual event propagation system, with a not-so-obvious name, and spread across at least three separate components of a Clutter Stage. I will probably open an issue in Mutter's repository to update their documentation about this.